### PR TITLE
feat: 添加MC百科自动链接功能

### DIFF
--- a/src/main/java/com/nododiiiii/ponderer/ai/McmodApiClient.java
+++ b/src/main/java/com/nododiiiii/ponderer/ai/McmodApiClient.java
@@ -1,0 +1,72 @@
+package com.nododiiiii.ponderer.ai;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Client for interacting with MCMod API to get item information
+ */
+public final class McmodApiClient {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private McmodApiClient() {
+    }
+
+    /**
+     * Get MCMod item URL for the given item display name
+     * 
+     * @param displayName Item display name
+     * @return Optional URL if found
+     */
+    public static Optional<String> getItemUrl(String displayName) {
+        try {
+            // Call MCMod API to get item ID
+            var client = HttpClientFactory.get();
+            String encodedName = URLEncoder.encode(displayName, StandardCharsets.UTF_8);
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.mcmod.cn/getItem/?regname=" + encodedName))
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+            String responseBody = response.body();
+
+            // Parse response to get item ID
+            int itemId = -1;
+            try {
+                // Simple parsing - assuming response is just the ID
+                itemId = Integer.parseInt(responseBody.trim());
+            } catch (NumberFormatException e) {
+                // Try to parse as JSON if available
+                try {
+                    JsonElement element = JsonParser.parseString(responseBody);
+                    if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()) {
+                        itemId = element.getAsInt();
+                    }
+                } catch (Exception ex) {
+                    // Ignore JSON parsing errors
+                }
+            }
+
+            if (itemId > 0) {
+                // Generate MCMod URL
+                String mcmodUrl = "https://www.mcmod.cn/item/" + itemId + ".html";
+                return Optional.of(mcmodUrl);
+            }
+        } catch (Exception e) {
+            // Log error and return empty
+            LOGGER.warn("Failed to get MCMod URL for item '{}': {}", displayName, e.getMessage());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/nododiiiii/ponderer/ui/CustomBackgroundTextFieldWidget.java
+++ b/src/main/java/com/nododiiiii/ponderer/ui/CustomBackgroundTextFieldWidget.java
@@ -1,0 +1,102 @@
+package com.nododiiiii.ponderer.ui;
+
+import net.createmod.catnip.config.ui.HintableTextFieldWidget;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+
+public class CustomBackgroundTextFieldWidget extends HintableTextFieldWidget {
+
+    /** Custom background color, or -1 for default. */
+    private int customBackgroundColor = -1;
+
+    public CustomBackgroundTextFieldWidget(Font font, int x, int y, int width, int height) {
+        super(font, x, y, width, height);
+    }
+
+    /**
+     * Set a custom background color for this text field.
+     * 
+     * @param color The background color in ARGB format, or -1 to use default
+     */
+    public void setBackgroundColor(int color) {
+        this.customBackgroundColor = color;
+    }
+
+    @Override
+    public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+        // Render custom background if set
+        if (customBackgroundColor != -1) {
+            graphics.fill(getX(), getY(), getX() + width, getY() + height, customBackgroundColor);
+            // Render border
+            graphics.fill(getX(), getY(), getX() + width, getY() + 1, 0xFF_666666);
+            graphics.fill(getX(), getY() + height - 1, getX() + width, getY() + height, 0xFF_666666);
+            graphics.fill(getX(), getY(), getX() + 1, getY() + height, 0xFF_666666);
+            graphics.fill(getX() + width - 1, getY(), getX() + width, getY() + height, 0xFF_666666);
+
+            // Render text
+            renderText(graphics);
+        } else {
+            super.renderWidget(graphics, mouseX, mouseY, partialTicks);
+        }
+    }
+
+    /**
+     * Render text without background
+     */
+    private void renderText(GuiGraphics graphics) {
+        // This is a simplified version of the text rendering logic
+        // It just draws the text, assuming the background is already rendered
+        String text = getValue();
+        int color = 0xFF_FFFFFF; // White text color
+
+        // Clip text to fit within the field, prioritizing the end of the text
+        int maxW = this.width - 10;
+        String displayText = text;
+
+        // Check if text fits without truncation
+        if (font.width(displayText) <= maxW) {
+            // Text fits completely, no truncation needed
+        } else {
+            // Calculate how much text we can show from the end
+            int ellipsisWidth = font.width("...");
+            int availableWidth = maxW - ellipsisWidth;
+
+            // Ensure availableWidth is positive
+            if (availableWidth <= 0) {
+                // Not enough space even for ellipsis, just show ellipsis
+                displayText = "...";
+            } else {
+                // Use character pointer approach: start from the end and move forward
+                StringBuilder sb = new StringBuilder();
+                int currentWidth = 0;
+
+                // Iterate from the end of the string to the beginning
+                for (int i = text.length() - 1; i >= 0; i--) {
+                    char c = text.charAt(i);
+                    String charStr = String.valueOf(c);
+                    int charWidth = font.width(charStr);
+
+                    // Check if adding this character would exceed the available width
+                    if (currentWidth + charWidth > availableWidth) {
+                        break;
+                    }
+
+                    // Add the character to the beginning of the string builder
+                    sb.insert(0, c);
+                    currentWidth += charWidth;
+                }
+
+                // If we found some text, show it with ellipsis
+                if (sb.length() > 0) {
+                    displayText = "..." + sb.toString();
+                } else {
+                    // Not enough space for any text, just show ellipsis
+                    displayText = "...";
+                }
+            }
+        }
+
+        // Draw text
+        graphics.drawString(font, displayText, getX() + 5, getY() + (height - 8) / 2, color);
+    }
+}

--- a/src/main/java/com/nododiiiii/ponderer/ui/ReferenceUrlManager.java
+++ b/src/main/java/com/nododiiiii/ponderer/ui/ReferenceUrlManager.java
@@ -1,0 +1,107 @@
+package com.nododiiiii.ponderer.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages URLs for the AI generate screen, including auto-added URLs
+ * and their relationship with selected items.
+ */
+public class ReferenceUrlManager {
+    public record ReferenceUrl(String url, boolean isAutoAdded) {
+    }
+
+    private final List<ReferenceUrl> referenceUrls = new ArrayList<>();
+
+    /**
+     * Add a URL to the manager.
+     * 
+     * @param url         The URL to add
+     * @param itemId      The item identifier associated with this URL
+     * @param isAutoAdded Whether this URL is auto-added (non-editable)
+     */
+    public void addUrl(String url, String itemId, boolean isAutoAdded) {
+        // Remove existing auto-added URLs for the previous item
+        removeAutoUrlsForItem();
+        // Add URL to the beginning of the list
+        referenceUrls.add(0, new ReferenceUrl(url, isAutoAdded));
+    }
+
+    /**
+     * Remove all auto-added URLs for the current item.
+     */
+    public void removeAutoUrlsForItem() {
+        // Remove existing auto-added URLs
+        for (int i = referenceUrls.size() - 1; i >= 0; i--) {
+            if (referenceUrls.get(i).isAutoAdded()) {
+                referenceUrls.remove(i);
+            }
+        }
+    }
+
+    /**
+     * Remove a URL at the specified index.
+     * 
+     * @param index The index of the URL to remove
+     */
+    public void removeUrl(int index) {
+        if (index >= 0 && index < referenceUrls.size()) {
+            referenceUrls.remove(index);
+        }
+    }
+
+    /**
+     * Add a manually added URL.
+     * 
+     * @param url The URL to add
+     */
+    public void addManualUrl(String url) {
+        referenceUrls.add(new ReferenceUrl(url, false));
+    }
+
+    /**
+     * Update a URL at the specified index.
+     * 
+     * @param index The index of the URL to update
+     * @param url   The new URL value
+     */
+    public void updateUrl(int index, String url) {
+        if (index >= 0 && index < referenceUrls.size()) {
+            ReferenceUrl oldUrl = referenceUrls.get(index);
+            referenceUrls.set(index, new ReferenceUrl(url, oldUrl.isAutoAdded()));
+        }
+    }
+
+    /**
+     * Get the list of URL values.
+     * 
+     * @return The list of URL values
+     */
+    public List<String> getUrlValues() {
+        List<String> urlValues = new ArrayList<>();
+        for (ReferenceUrl refUrl : referenceUrls) {
+            urlValues.add(refUrl.url());
+        }
+        return urlValues;
+    }
+
+    /**
+     * Get the list indicating whether each URL is auto-added.
+     * 
+     * @return The list of auto-added flags
+     */
+    public List<Boolean> getUrlAutoAdded() {
+        List<Boolean> autoAddedFlags = new ArrayList<>();
+        for (ReferenceUrl refUrl : referenceUrls) {
+            autoAddedFlags.add(refUrl.isAutoAdded());
+        }
+        return autoAddedFlags;
+    }
+
+    /**
+     * Clear all URLs.
+     */
+    public void clear() {
+        referenceUrls.clear();
+    }
+}

--- a/src/main/resources/assets/ponderer/lang/en_us.json
+++ b/src/main/resources/assets/ponderer/lang/en_us.json
@@ -447,8 +447,6 @@
   "ponderer.ui.pick.tooltip": "Pick",
 
   "ponderer.cmd.export.done": "Ponderer: exported %s files to %s",
-  "ponderer.ui.ai_generate.url.added": "URL added",
-  "ponderer.ui.ai_generate.url.jei.hint": "Click J to add MCMod URL",
   "ponderer.cmd.export.failed": "Ponderer: export failed: %s",
   "ponderer.cmd.import.done": "Ponderer: imported %s files from %s",
   "ponderer.cmd.import.failed": "Ponderer: import failed: %s",

--- a/src/main/resources/assets/ponderer/lang/en_us.json
+++ b/src/main/resources/assets/ponderer/lang/en_us.json
@@ -447,6 +447,8 @@
   "ponderer.ui.pick.tooltip": "Pick",
 
   "ponderer.cmd.export.done": "Ponderer: exported %s files to %s",
+  "ponderer.ui.ai_generate.url.added": "URL added",
+  "ponderer.ui.ai_generate.url.jei.hint": "Click J to add MCMod URL",
   "ponderer.cmd.export.failed": "Ponderer: export failed: %s",
   "ponderer.cmd.import.done": "Ponderer: imported %s files from %s",
   "ponderer.cmd.import.failed": "Ponderer: import failed: %s",
@@ -586,6 +588,7 @@
   "ponderer.ui.ai_generate.add_url": "+ Add URL",
   "ponderer.ui.ai_generate.build_tutorial": "Build Tutorial",
   "ponderer.ui.ai_generate.include_images": "Include Images",
+  "ponderer.ui.ai_generate.url.mcmod": "[MC Mod]",
   "ponderer.ui.ai_generate.generate": "Generate",
   "ponderer.ui.ai_generate.generating": "Generating...",
   "ponderer.ui.ai_generate.error.no_structure": "Add at least one structure",

--- a/src/main/resources/assets/ponderer/lang/zh_cn.json
+++ b/src/main/resources/assets/ponderer/lang/zh_cn.json
@@ -567,7 +567,5 @@
   "ponderer.ui.ai_generate.add_url.tooltip": "添加参考网页链接，AI 会抓取内容作为参考",
   "ponderer.ui.ai_generate.build_tutorial.tooltip": "开启后第一个场景为逐层搭建教程",
   "ponderer.ui.ai_generate.include_images.tooltip": "开启后会截取参考网页的图片发送给 AI",
-  "ponderer.ui.ai_generate.generate.tooltip": "开始生成思索场景（需要先配置 AI）",
-  "ponderer.ui.ai_generate.url.added": "URL已添加",
-  "ponderer.ui.ai_generate.url.jei.hint": "点击J添加MC百科链接"
+  "ponderer.ui.ai_generate.generate.tooltip": "开始生成思索场景（需要先配置 AI）"
 }

--- a/src/main/resources/assets/ponderer/lang/zh_cn.json
+++ b/src/main/resources/assets/ponderer/lang/zh_cn.json
@@ -547,6 +547,7 @@
   "ponderer.ui.ai_generate.add_url": "+ 添加网址",
   "ponderer.ui.ai_generate.build_tutorial": "搭建教程",
   "ponderer.ui.ai_generate.include_images": "附带图片",
+  "ponderer.ui.ai_generate.url.mcmod": "[MC百科]",
   "ponderer.ui.ai_generate.generate": "生成",
   "ponderer.ui.ai_generate.generating": "生成中...",
   "ponderer.ui.ai_generate.error.no_structure": "请至少添加一个结构",
@@ -566,5 +567,7 @@
   "ponderer.ui.ai_generate.add_url.tooltip": "添加参考网页链接，AI 会抓取内容作为参考",
   "ponderer.ui.ai_generate.build_tutorial.tooltip": "开启后第一个场景为逐层搭建教程",
   "ponderer.ui.ai_generate.include_images.tooltip": "开启后会截取参考网页的图片发送给 AI",
-  "ponderer.ui.ai_generate.generate.tooltip": "开始生成思索场景（需要先配置 AI）"
+  "ponderer.ui.ai_generate.generate.tooltip": "开始生成思索场景（需要先配置 AI）",
+  "ponderer.ui.ai_generate.url.added": "URL已添加",
+  "ponderer.ui.ai_generate.url.jei.hint": "点击J添加MC百科链接"
 }


### PR DESCRIPTION
为AI生成界面新增自动获取MC百科链接功能：
- 实现 JEI 集成，通过物品点击自动生成 MCMod URL
- 为自动添加的 URL 添加特殊视觉效果（暗色背景和 [MC百科] 标签），并支持i18n

### 其他细节
* 自动抓取的MCMod URL不支持手动修改，防止不小心改错了导致拉取不到正确的网页
* 虽然不支持修改，但是如果不想要的话，可以直接删除这个自动拉取的url
* 一些物品在MCMod上拉取不到对应的详情页，就不会有这个自动拉取的url出现了

### 附加说明
* McMod Url的自动生成，参考https://www.mcmod.cn/class/17975.html 的实现，感谢大佬的铺路
* 由于不太了解作者大大对此mod版本号change的规范，本次pr中没有修改版本号，辛苦作者大大自行修改了
* 测试游戏版本：Minecraft Java 1.20.1

<img width="746" height="948" alt="1772364416870" src="https://github.com/user-attachments/assets/f305cc8a-6ccc-4927-a660-776f038173af" />
