### PR TITLE
修复配置界面文本输入存在32字符上限的问题

### DIFF
--- a/Forge/src/main/java/com/nododiiiii/ponderer/mixin/StringEntryAccessor.java
+++ b/Forge/src/main/java/com/nododiiiii/ponderer/mixin/StringEntryAccessor.java
@@ -1,0 +1,13 @@
+package com.nododiiiii.ponderer.mixin;
+
+import net.createmod.catnip.config.ui.entries.StringEntry;
+import net.minecraft.client.gui.components.EditBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(StringEntry.class)
+public interface StringEntryAccessor {
+
+    @Accessor("textField")
+    EditBox ponderer$getTextField();
+}

--- a/Forge/src/main/java/com/nododiiiii/ponderer/mixin/StringEntryMaxLengthMixin.java
+++ b/Forge/src/main/java/com/nododiiiii/ponderer/mixin/StringEntryMaxLengthMixin.java
@@ -1,0 +1,24 @@
+package com.nododiiiii.ponderer.mixin;
+
+import net.createmod.catnip.config.ui.entries.StringEntry;
+import net.minecraft.client.gui.components.EditBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(StringEntry.class)
+public class StringEntryMaxLengthMixin {
+
+    private static final int PONDERER_MAX_LENGTH = 65536;
+
+    @Inject(method = "<init>", at = @At("TAIL"), remap = false)
+    private void ponderer$raiseMaxLength(String label, net.minecraftforge.common.ForgeConfigSpec.ConfigValue<String> value,
+                                         net.minecraftforge.common.ForgeConfigSpec.ValueSpec spec, CallbackInfo ci) {
+        EditBox textField = ((StringEntryAccessor) (Object) this).ponderer$getTextField();
+        if (textField != null) {
+            textField.setMaxLength(PONDERER_MAX_LENGTH);
+            textField.setValue(value.get());
+        }
+    }
+}

--- a/Forge/src/main/resources/ponderer.mixins.json
+++ b/Forge/src/main/resources/ponderer.mixins.json
@@ -33,7 +33,9 @@
     "PonderUIMirrorRenderMixin",
     "JeiGuiEventHandlerMixin",
     "EmbeddedMirrorContainerScreenMixin",
-    "PonderProgressBarAccessorMixin"
+    "PonderProgressBarAccessorMixin",
+    "StringEntryAccessor",
+    "StringEntryMaxLengthMixin"
   ],
   "server": [],
   "injectors": {


### PR DESCRIPTION
## 问题
Forge Mods 配置界面（catnip `StringEntry`）的文本输入框默认 `maxLength=32`，导致 `ai.apiKey` 等较长配置在输入、保存重开后显示均被截断，长 key 无法正常使用。

## 修复
- 新增 `StringEntryAccessor`：访问 `StringEntry` 的 `textField` 字段
- 新增 `StringEntryMaxLengthMixin`：在 `StringEntry.<init>` 构造完成后将 `EditBox` 的 `maxLength` 提升至 65536，并重设初始值，使保存后重开界面不再截断显示
- `ponderer.mixins.json` 注册以上两个 mixin

## 验证
已在本地 Forge 1.20.1 (47.4.9) 实测：可输入超过 32 字符的配置，保存后重开界面显示完整。